### PR TITLE
fix: propagate policy parse errors in string adapter LoadPolicy

### DIFF
--- a/persist/string-adapter/adapter.go
+++ b/persist/string-adapter/adapter.go
@@ -49,7 +49,9 @@ func (a *Adapter) LoadPolicy(model model.Model) error {
 		if str == "" {
 			continue
 		}
-		_ = persist.LoadPolicyLine(str, model)
+		if err := persist.LoadPolicyLine(str, model); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/persist/string-adapter/adapter_test.go
+++ b/persist/string-adapter/adapter_test.go
@@ -171,3 +171,16 @@ g, alice, data_group_admin
 		t.Error("unexpected enforce result")
 	}
 }
+
+// Test_LoadPolicyMalformedLine verifies that a malformed policy line (here an
+// unterminated quoted field) makes LoadPolicy return an error instead of
+// silently producing a model that lacks the rule.
+func Test_LoadPolicyMalformedLine(t *testing.T) {
+	a := NewAdapter(`p, alice, data1, "read`)
+	m := model.NewModel()
+
+	err := a.LoadPolicy(m)
+	if err == nil {
+		t.Fatal("LoadPolicy() error = nil, want a parse error for the unterminated quoted field")
+	}
+}


### PR DESCRIPTION
## Description

`stringadapter.Adapter.LoadPolicy` discards the error returned by `persist.LoadPolicyLine`:

```go
for _, str := range strs {
    if str == "" {
        continue
    }
    _ = persist.LoadPolicyLine(str, model)
}
```

A malformed line (e.g. an unterminated quoted field: `p, alice, data1, "read`) is therefore silently skipped: `LoadPolicy` returns `nil`, the model simply lacks the rule, and `Enforce` returns `false` with no error — the caller has no way to notice the typo'd policy.

The file adapter propagates the same error (`persist/file-adapter/adapter.go` `loadPolicyFile` returns `handler(line, model)` errors), and `LoadPolicyLine`/`LoadPolicyArray` return errors precisely so callers can report malformed policies (see also #1106). This PR aligns the string adapter with that contract by returning the error.

## Testing

- Added `Test_LoadPolicyMalformedLine` in `persist/string-adapter/adapter_test.go`: an adapter line with an unterminated quoted field must make `LoadPolicy` return an error.
  - Before the fix: FAIL — `LoadPolicy() error = nil, want a parse error for the unterminated quoted field`
  - After the fix: PASS
- All existing tests in the package (`Test_KeyMatchRbac`, `Test_SavePolicyRoundTripWithCommas`, `Test_StringRbac`) still pass, and the full `go test ./...` suite passes (8 packages, no failures).
- `go vet ./persist/string-adapter/` clean.

Behavior change is limited to inputs that previously produced a silently-wrong model; well-formed input loads exactly as before.

---

*This PR was prepared with AI assistance (GitHub Copilot / ZCode autonomous agent). All findings were verified manually against the codebase before submission.*
